### PR TITLE
spec2deb.py: use `-a` instead of `&&` for postinst scripts

### DIFF
--- a/src/spec2deb/spec2deb.py
+++ b/src/spec2deb/spec2deb.py
@@ -1092,8 +1092,8 @@ class RpmSpecToDebianControl:
         fi
         """
         postinst = """
-        if   [ "configure" = "$1" && "." = ".$2" ]; then  shift ; set -- "1" "$@"
-        elif [ "configure" = "$1" && "." != ".$2" ]; then shift ; set -- "2" "$@"
+        if   [ "configure" = "$1" -a "." = ".$2" ]; then  shift ; set -- "1" "$@"
+        elif [ "configure" = "$1" -a "." != ".$2" ]; then shift ; set -- "2" "$@"
         fi
         """
         prerm = """


### PR DESCRIPTION
fixes warnings after PKG_NAME install:
/var/lib/dpkg/info/PKG_NAME.postinst: 2: [: missing ]
/var/lib/dpkg/info/PKG_NAME.postinst: 3: [: missing ]